### PR TITLE
Bumped the base version constraint.

### DIFF
--- a/datetime.cabal
+++ b/datetime.cabal
@@ -42,7 +42,7 @@ test-suite test
       , old-time >= 1.0.0.1
       , time >= 1.1.2.2
 
-      , base >=4.2 && <4.9
+      , base >=4.2 && <5
       , test-framework
       , HUnit
       , QuickCheck


### PR DESCRIPTION
The version constraint for base in the test section did not match the
rest of the package. Also this causes the package to not build on GHC
> 8.2.1 which ships with base 4.10.